### PR TITLE
Remove flex from a tags for social icons.

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -800,8 +800,6 @@ a.button {
     place-content: center;
 
     a {
-      display: flex;
-
       .social {
         cursor: pointer;
         margin: auto;


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Makes the social icons the correct size on Safari.

**Migration**
None

**Dependencies**
None
